### PR TITLE
Optional comments

### DIFF
--- a/ckanext/datarequests/plugin.py
+++ b/ckanext/datarequests/plugin.py
@@ -23,6 +23,14 @@ import auth
 import actions
 import constants
 
+from pylons import config
+
+
+def get_config_bool_value(config_name, default_value=False):
+    value = config.get(config_name, default_value)
+    value = value if type(value) == bool else value != 'False'
+    return value
+
 
 class DataRequestsPlugin(p.SingletonPlugin):
 
@@ -30,33 +38,40 @@ class DataRequestsPlugin(p.SingletonPlugin):
     p.implements(p.IAuthFunctions)
     p.implements(p.IConfigurer)
     p.implements(p.IRoutes, inherit=True)
+    p.implements(p.ITemplateHelpers)
+
+    def __init__(self, name=None):
+        self.comments_enabled = get_config_bool_value('ckan.datarequests.comments', True)
 
     ######################################################################
     ############################## IACTIONS ##############################
     ######################################################################
 
     def get_actions(self):
-        return {
+        functions = {
             constants.DATAREQUEST_CREATE: actions.datarequest_create,
             constants.DATAREQUEST_SHOW: actions.datarequest_show,
             constants.DATAREQUEST_UPDATE: actions.datarequest_update,
             constants.DATAREQUEST_INDEX: actions.datarequest_index,
             constants.DATAREQUEST_DELETE: actions.datarequest_delete,
-            constants.DATAREQUEST_CLOSE: actions.datarequest_close,
-            constants.DATAREQUEST_COMMENT: actions.datarequest_comment,
-            constants.DATAREQUEST_COMMENT_LIST: actions.datarequest_comment_list,
-            constants.DATAREQUEST_COMMENT_SHOW: actions.datarequest_comment_show,
-            constants.DATAREQUEST_COMMENT_UPDATE: actions.datarequest_comment_update,
-            constants.DATAREQUEST_COMMENT_DELETE: actions.datarequest_comment_delete
-
+            constants.DATAREQUEST_CLOSE: actions.datarequest_close
         }
+
+        if self.comments_enabled:
+            functions[constants.DATAREQUEST_COMMENT] = actions.datarequest_comment
+            functions[constants.DATAREQUEST_COMMENT_LIST] = actions.datarequest_comment_list
+            functions[constants.DATAREQUEST_COMMENT_SHOW] = actions.datarequest_comment_show
+            functions[constants.DATAREQUEST_COMMENT_UPDATE] = actions.datarequest_comment_update
+            functions[constants.DATAREQUEST_COMMENT_DELETE] = actions.datarequest_comment_delete
+
+        return functions
 
     ######################################################################
     ########################### AUTH FUNCTIONS ###########################
     ######################################################################
 
     def get_auth_functions(self):
-        return {
+        auth_functions = {
             constants.DATAREQUEST_CREATE: auth.datarequest_create,
             constants.DATAREQUEST_SHOW: auth.datarequest_show,
             constants.DATAREQUEST_UPDATE: auth.datarequest_update,
@@ -69,6 +84,15 @@ class DataRequestsPlugin(p.SingletonPlugin):
             constants.DATAREQUEST_COMMENT_UPDATE: auth.datarequest_comment_update,
             constants.DATAREQUEST_COMMENT_DELETE: auth.datarequest_comment_delete
         }
+
+        if self.comments_enabled:
+            auth_functions[constants.DATAREQUEST_COMMENT] = auth.datarequest_comment,
+            auth_functions[constants.DATAREQUEST_COMMENT_LIST] = auth.datarequest_comment_list
+            auth_functions[constants.DATAREQUEST_COMMENT_SHOW] = auth.datarequest_comment_show
+            auth_functions[constants.DATAREQUEST_COMMENT_UPDATE] = auth.datarequest_comment_update
+            auth_functions[constants.DATAREQUEST_COMMENT_DELETE] = auth.datarequest_comment_delete
+
+        return auth_functions
 
     ######################################################################
     ############################ ICONFIGURER #############################
@@ -126,14 +150,26 @@ class DataRequestsPlugin(p.SingletonPlugin):
                   action='organization_datarequests', conditions=dict(method=['GET']),
                   ckan_icon='question-sign')
 
-        # Comment, update and view comments (of) a Data Request
-        m.connect('datarequest_comment', '/%s/comment/{id}' % constants.DATAREQUESTS_MAIN_PATH,
-                  controller='ckanext.datarequests.controllers.ui_controller:DataRequestsUI',
-                  action='comment', conditions=dict(method=['GET', 'POST']), ckan_icon='comment')
+        if self.comments_enabled:
+            # Comment, update and view comments (of) a Data Request
+            m.connect('datarequest_comment', '/%s/comment/{id}' % constants.DATAREQUESTS_MAIN_PATH,
+                      controller='ckanext.datarequests.controllers.ui_controller:DataRequestsUI',
+                      action='comment', conditions=dict(method=['GET', 'POST']), ckan_icon='comment')
 
-        # Delete data request
-        m.connect('/%s/comment/{datarequest_id}/delete/{comment_id}' % constants.DATAREQUESTS_MAIN_PATH,
-                  controller='ckanext.datarequests.controllers.ui_controller:DataRequestsUI',
-                  action='delete_comment', conditions=dict(method=['GET', 'POST']))
+            # Delete data request
+            m.connect('/%s/comment/{datarequest_id}/delete/{comment_id}' % constants.DATAREQUESTS_MAIN_PATH,
+                      controller='ckanext.datarequests.controllers.ui_controller:DataRequestsUI',
+                      action='delete_comment', conditions=dict(method=['GET', 'POST']))
 
         return m
+
+    ######################################################################
+    ######################### ITEMPLATESHELPER ###########################
+    ######################################################################
+
+    def get_helpers(self):
+
+        def _show_comments_tab():
+            return self.comments_enabled
+
+        return {'show_comments_tab': _show_comments_tab }

--- a/ckanext/datarequests/plugin.py
+++ b/ckanext/datarequests/plugin.py
@@ -48,7 +48,7 @@ class DataRequestsPlugin(p.SingletonPlugin):
     ######################################################################
 
     def get_actions(self):
-        functions = {
+        additional_actions = {
             constants.DATAREQUEST_CREATE: actions.datarequest_create,
             constants.DATAREQUEST_SHOW: actions.datarequest_show,
             constants.DATAREQUEST_UPDATE: actions.datarequest_update,
@@ -58,13 +58,13 @@ class DataRequestsPlugin(p.SingletonPlugin):
         }
 
         if self.comments_enabled:
-            functions[constants.DATAREQUEST_COMMENT] = actions.datarequest_comment
-            functions[constants.DATAREQUEST_COMMENT_LIST] = actions.datarequest_comment_list
-            functions[constants.DATAREQUEST_COMMENT_SHOW] = actions.datarequest_comment_show
-            functions[constants.DATAREQUEST_COMMENT_UPDATE] = actions.datarequest_comment_update
-            functions[constants.DATAREQUEST_COMMENT_DELETE] = actions.datarequest_comment_delete
+            additional_actions[constants.DATAREQUEST_COMMENT] = actions.datarequest_comment
+            additional_actions[constants.DATAREQUEST_COMMENT_LIST] = actions.datarequest_comment_list
+            additional_actions[constants.DATAREQUEST_COMMENT_SHOW] = actions.datarequest_comment_show
+            additional_actions[constants.DATAREQUEST_COMMENT_UPDATE] = actions.datarequest_comment_update
+            additional_actions[constants.DATAREQUEST_COMMENT_DELETE] = actions.datarequest_comment_delete
 
-        return functions
+        return additional_actions
 
     ######################################################################
     ########################### AUTH FUNCTIONS ###########################
@@ -78,15 +78,10 @@ class DataRequestsPlugin(p.SingletonPlugin):
             constants.DATAREQUEST_INDEX: auth.datarequest_index,
             constants.DATAREQUEST_DELETE: auth.datarequest_delete,
             constants.DATAREQUEST_CLOSE: auth.datarequest_close,
-            constants.DATAREQUEST_COMMENT: auth.datarequest_comment,
-            constants.DATAREQUEST_COMMENT_LIST: auth.datarequest_comment_list,
-            constants.DATAREQUEST_COMMENT_SHOW: auth.datarequest_comment_show,
-            constants.DATAREQUEST_COMMENT_UPDATE: auth.datarequest_comment_update,
-            constants.DATAREQUEST_COMMENT_DELETE: auth.datarequest_comment_delete
         }
 
         if self.comments_enabled:
-            auth_functions[constants.DATAREQUEST_COMMENT] = auth.datarequest_comment,
+            auth_functions[constants.DATAREQUEST_COMMENT] = auth.datarequest_comment
             auth_functions[constants.DATAREQUEST_COMMENT_LIST] = auth.datarequest_comment_list
             auth_functions[constants.DATAREQUEST_COMMENT_SHOW] = auth.datarequest_comment_show
             auth_functions[constants.DATAREQUEST_COMMENT_UPDATE] = auth.datarequest_comment_update
@@ -168,8 +163,4 @@ class DataRequestsPlugin(p.SingletonPlugin):
     ######################################################################
 
     def get_helpers(self):
-
-        def _show_comments_tab():
-            return self.comments_enabled
-
-        return {'show_comments_tab': _show_comments_tab }
+        return {'show_comments_tab': lambda: self.comments_enabled}

--- a/ckanext/datarequests/templates/datarequests/show.html
+++ b/ckanext/datarequests/templates/datarequests/show.html
@@ -23,7 +23,10 @@
 
 {% block content_primary_nav %}
   {{ h.build_nav_icon('datarequest_show', _('Data Request'), id=datarequest_id) }}
-  {{ h.build_nav_icon('datarequest_comment', _('Comments'), id=datarequest_id) }}
+
+  {% if h.show_comments_tab() %}
+    {{ h.build_nav_icon('datarequest_comment', _('Comments'), id=datarequest_id) }}
+  {% endif %}
 {% endblock %}
 
 {% block secondary_content %}

--- a/ckanext/datarequests/tests/test_plugin.py
+++ b/ckanext/datarequests/tests/test_plugin.py
@@ -22,6 +22,11 @@ import ckanext.datarequests.constants as constants
 import unittest
 
 from mock import MagicMock
+from nose_parameterized import parameterized
+
+TOTAL_ACTIONS = 11
+COMMENTS_ACTIONS = 5
+ACTIONS_NO_COMMENTS = TOTAL_ACTIONS - COMMENTS_ACTIONS
 
 
 class DataRequestPlutinTest(unittest.TestCase):
@@ -36,8 +41,10 @@ class DataRequestPlutinTest(unittest.TestCase):
         self._tk = plugin.tk
         plugin.tk = MagicMock()
 
+        self._config = plugin.config
+        plugin.config = MagicMock()
+
         # plg = plugin
-        self.plg_instance = plugin.DataRequestsPlugin()
         self.datarequest_create = constants.DATAREQUEST_CREATE
         self.datarequest_show = constants.DATAREQUEST_SHOW
         self.datarequest_update = constants.DATAREQUEST_UPDATE
@@ -49,52 +56,96 @@ class DataRequestPlutinTest(unittest.TestCase):
         self.datarequest_comment_update = constants.DATAREQUEST_COMMENT_UPDATE
         self.datarequest_comment_delete = constants.DATAREQUEST_COMMENT_DELETE
 
-
     def tearDown(self):
         plugin.actions = self._actions
         plugin.auth = self._auth
         plugin.tk = self._tk
 
-    def test_get_actions(self):
+    @parameterized.expand([
+        ('True',),
+        ('False',)
+    ])
+    def test_get_actions(self, comments_enabled):
+
+        actions_len = TOTAL_ACTIONS if comments_enabled == 'True' else ACTIONS_NO_COMMENTS
+
+        # Configure config and create instance
+        plugin.config.get.return_value = comments_enabled
+        self.plg_instance = plugin.DataRequestsPlugin()
+
+        # Get actions
         actions = self.plg_instance.get_actions()
-        self.assertEquals(11, len(actions))
+
+        self.assertEquals(actions_len, len(actions))
         self.assertEquals(plugin.actions.datarequest_create, actions[self.datarequest_create])
         self.assertEquals(plugin.actions.datarequest_show, actions[self.datarequest_show])
         self.assertEquals(plugin.actions.datarequest_update, actions[self.datarequest_update])
         self.assertEquals(plugin.actions.datarequest_index, actions[self.datarequest_index])
         self.assertEquals(plugin.actions.datarequest_delete, actions[self.datarequest_delete])
-        self.assertEquals(plugin.actions.datarequest_comment, actions[self.datarequest_comment])
-        self.assertEquals(plugin.actions.datarequest_comment_list, actions[self.datarequest_comment_list])
-        self.assertEquals(plugin.actions.datarequest_comment_show, actions[self.datarequest_comment_show])
-        self.assertEquals(plugin.actions.datarequest_comment_update, actions[self.datarequest_comment_update])
-        self.assertEquals(plugin.actions.datarequest_comment_delete, actions[self.datarequest_comment_delete])
 
-    def test_get_auth_functions(self):
+        if comments_enabled == 'True':
+            self.assertEquals(plugin.actions.datarequest_comment, actions[self.datarequest_comment])
+            self.assertEquals(plugin.actions.datarequest_comment_list, actions[self.datarequest_comment_list])
+            self.assertEquals(plugin.actions.datarequest_comment_show, actions[self.datarequest_comment_show])
+            self.assertEquals(plugin.actions.datarequest_comment_update, actions[self.datarequest_comment_update])
+            self.assertEquals(plugin.actions.datarequest_comment_delete, actions[self.datarequest_comment_delete])
+
+    @parameterized.expand([
+        ('True',),
+        ('False',)
+    ])
+    def test_get_auth_functions(self, comments_enabled):
+
+        auth_functions_len = TOTAL_ACTIONS if comments_enabled == 'True' else ACTIONS_NO_COMMENTS
+
+        # Configure config and create instance
+        plugin.config.get.return_value = comments_enabled
+        self.plg_instance = plugin.DataRequestsPlugin()
+
+        # Get auth functions
         auth_functions = self.plg_instance.get_auth_functions()
-        self.assertEquals(11, len(auth_functions))
+
+        self.assertEquals(auth_functions_len, len(auth_functions))
         self.assertEquals(plugin.auth.datarequest_create, auth_functions[self.datarequest_create])
         self.assertEquals(plugin.auth.datarequest_show, auth_functions[self.datarequest_show])
         self.assertEquals(plugin.auth.datarequest_update, auth_functions[self.datarequest_update])
         self.assertEquals(plugin.auth.datarequest_index, auth_functions[self.datarequest_index])
         self.assertEquals(plugin.auth.datarequest_delete, auth_functions[self.datarequest_delete])
-        self.assertEquals(plugin.auth.datarequest_comment, auth_functions[self.datarequest_comment])
-        self.assertEquals(plugin.auth.datarequest_comment_list, auth_functions[self.datarequest_comment_list])
-        self.assertEquals(plugin.auth.datarequest_comment_show, auth_functions[self.datarequest_comment_show])
-        self.assertEquals(plugin.auth.datarequest_comment_update, auth_functions[self.datarequest_comment_update])
-        self.assertEquals(plugin.auth.datarequest_comment_delete, auth_functions[self.datarequest_comment_delete])
 
+        if comments_enabled == 'True':
+            self.assertEquals(plugin.auth.datarequest_comment, auth_functions[self.datarequest_comment])
+            self.assertEquals(plugin.auth.datarequest_comment_list, auth_functions[self.datarequest_comment_list])
+            self.assertEquals(plugin.auth.datarequest_comment_show, auth_functions[self.datarequest_comment_show])
+            self.assertEquals(plugin.auth.datarequest_comment_update, auth_functions[self.datarequest_comment_update])
+            self.assertEquals(plugin.auth.datarequest_comment_delete, auth_functions[self.datarequest_comment_delete])
 
     def test_update_config(self):
+        # Create instance
+        self.plg_instance = plugin.DataRequestsPlugin()
+
+        # Test
         config = MagicMock()
         self.plg_instance.update_config(config)
         plugin.tk.add_template_directory.assert_called_once_with(config, 'templates')
 
-    def test_before_map(self):
+    @parameterized.expand([
+        ('True',),
+        ('False')
+    ])
+    def test_before_map(self, comments_enabled):
+
+        mapa_calls = 9 if comments_enabled == 'True' else 9 - 2
+
+        # Configure config and get instance
+        plugin.config.get.return_value = comments_enabled
+        self.plg_instance = plugin.DataRequestsPlugin()
+
+        # Test
         mapa = MagicMock()
         dr_basic_path = 'datarequest'
         self.plg_instance.before_map(mapa)
 
-        self.assertEquals(9, mapa.connect.call_count)
+        self.assertEquals(mapa_calls, mapa.connect.call_count)
         mapa.connect.assert_any_call('datarequests_index', "/%s" % dr_basic_path,
             controller='ckanext.datarequests.controllers.ui_controller:DataRequestsUI',
             action='index', conditions=dict(method=['GET']))
@@ -125,10 +176,11 @@ class DataRequestPlutinTest(unittest.TestCase):
             action='organization_datarequests', conditions=dict(method=['GET']), 
             ckan_icon='question-sign')
 
-        mapa.connect.assert_any_call('datarequest_comment', '/%s/comment/{id}' % dr_basic_path,
-                  controller='ckanext.datarequests.controllers.ui_controller:DataRequestsUI',
-                  action='comment', conditions=dict(method=['GET', 'POST']), ckan_icon='comment')
+        if comments_enabled == 'True':
+            mapa.connect.assert_any_call('datarequest_comment', '/%s/comment/{id}' % dr_basic_path,
+                controller='ckanext.datarequests.controllers.ui_controller:DataRequestsUI',
+                action='comment', conditions=dict(method=['GET', 'POST']), ckan_icon='comment')
 
-        mapa.connect.assert_any_call('/%s/comment/{datarequest_id}/delete/{comment_id}' % dr_basic_path,
-                  controller='ckanext.datarequests.controllers.ui_controller:DataRequestsUI',
-                  action='delete_comment', conditions=dict(method=['GET', 'POST']))
+            mapa.connect.assert_any_call('/%s/comment/{datarequest_id}/delete/{comment_id}' % dr_basic_path,
+                controller='ckanext.datarequests.controllers.ui_controller:DataRequestsUI',
+                action='delete_comment', conditions=dict(method=['GET', 'POST']))


### PR DESCRIPTION
Fix #6: Comments are now optional. Managers can enable/disable them by setting up the `ckan.datarequests.comments` preference in the config file.