### PR TITLE
Additional tab to see user datarequests

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Returns a list with the existing data requests. Rights access will be checked be
     
 ##### Parameters (included in `data_dict`):
 * **`organization_id`** (string) (optional): to filter the result by organization
+* **`user_id`** (string) (optional): to filter the result by user
 * **`closed`** (string) (optional): to filter the result by state (`True`: Closed, `False`: Open)
 * **`offset`** (int) (optional) (default `0`): the first element to be returned
 * **`limit`** (int) (optional) (default `10`): The max number of data requests to be returned

--- a/ckanext/datarequests/actions.py
+++ b/ckanext/datarequests/actions.py
@@ -281,6 +281,10 @@ def datarequest_index(context, data_dict):
         to filter the results by organization
     :type organization_id: string
 
+    :param user_id: This parameter is optional and allows users
+        to filter the results by user
+    :type organization_id: string
+
     :param closed: This parameter is optional and allos users to filter
         the result by the data request status (open or closed)
     :type closed: bool
@@ -292,13 +296,14 @@ def datarequest_index(context, data_dict):
     :type limit: init
 
     :returns: A dict with three fields: result (a list of data requests),
-        facets (a list of the facets that can be used) and count (the total 
+        facets (a list of the facets that can be used) and count (the total
         number of existing data requests)
     :rtype: dict
     '''
 
     model = context['model']
     organization_show = tk.get_action('organization_show')
+    user_show = tk.get_action('user_show')
 
     # Init the data base
     db.init_db(model)
@@ -310,11 +315,19 @@ def datarequest_index(context, data_dict):
     organization_id = data_dict.get('organization_id', None)
     params = {}
     if organization_id:
-        # Get organization ID (in some cases, user give the system the organization name)
+        # Get organization ID (in some cases the organization name is received)
         organization_id = organization_show({'ignore_auth': True}, {'id': organization_id}).get('id')
 
-        # Include the organization into the parameters to filter the database query
+        # Include organization ID into the parameters to filter the database query
         params['organization_id'] = organization_id
+
+    user_id = data_dict.get('user_id', None)
+    if user_id:
+        # Get user ID (the user name is received)
+        user_id = user_show({'ignore_auth': True}, {'id': user_id}).get('id')
+
+        # Include user ID into the parameters to filter the database query
+        params['user_id'] = user_id
 
     # Filter by state
     closed = data_dict.get('closed', None)

--- a/ckanext/datarequests/controllers/ui_controller.py
+++ b/ckanext/datarequests/controllers/ui_controller.py
@@ -79,13 +79,19 @@ def org_datarequest_url(params, id):
     return url_with_params(url, params)
 
 
+def user_datarequest_url(params, id):
+    url = helpers.url_for(controller='ckanext.datarequests.controllers.ui_controller:DataRequestsUI',
+                          action='user_datarequests', id=id)
+    return url_with_params(url, params)
+
+
 class DataRequestsUI(base.BaseController):
 
     def _get_context(self):
         return {'model': model, 'session': model.Session,
                 'user': c.user, 'auth_user_obj': c.userobj}
 
-    def _show_index(self, organization_id, include_organization_facet, url_func, file_to_render):
+    def _show_index(self, user_id, organization_id, include_organization_facet, url_func, file_to_render):
 
         def pager_url(q=None, page=None):
             params = list()
@@ -105,6 +111,9 @@ class DataRequestsUI(base.BaseController):
 
             if organization_id:
                 data_dict['organization_id'] = organization_id
+
+            if user_id:
+                data_dict['user_id'] = user_id
 
             tk.check_access(constants.DATAREQUEST_INDEX, context, data_dict)
             datarequests_list = tk.get_action(constants.DATAREQUEST_INDEX)(context, data_dict)
@@ -136,7 +145,7 @@ class DataRequestsUI(base.BaseController):
             tk.abort(403, tk._('Unauthorized to list Data Requests'))
 
     def index(self):
-        return self._show_index(request.GET.get('organization', ''), True, search_url, 'datarequests/index.html')
+        return self._show_index(None, request.GET.get('organization', ''), True, search_url, 'datarequests/index.html')
 
     def _process_post(self, action, context):
         # If the user has submitted the form, the data request must be created
@@ -251,7 +260,13 @@ class DataRequestsUI(base.BaseController):
         context = self._get_context()
         c.group_dict = tk.get_action('organization_show')(context, {'id': id})
         url_func = functools.partial(org_datarequest_url, id=id)
-        return self._show_index(id, False, url_func, 'organization/datarequests.html')
+        return self._show_index(None, id, False, url_func, 'organization/datarequests.html')
+
+    def user_datarequests(self, id):
+        context = self._get_context()
+        c.user_dict = tk.get_action('user_show')(context, {'id': id, 'include_num_followers': True})
+        url_func = functools.partial(user_datarequest_url, id=id)
+        return self._show_index(id, None, True, url_func, 'user/datarequests.html')
 
     def close(self, id):
         data_dict = {'id': id}

--- a/ckanext/datarequests/controllers/ui_controller.py
+++ b/ckanext/datarequests/controllers/ui_controller.py
@@ -252,7 +252,7 @@ class DataRequestsUI(base.BaseController):
             log.warn(e)
             tk.abort(404, tk._('Data Request %s not found') % id)
         except tk.NotAuthorized as e:
-            log.warn(e)
+            log.warn(e) 
             tk.abort(403, tk._('You are not authorized to delete the Data Request %s'
                                % id))
 
@@ -266,7 +266,7 @@ class DataRequestsUI(base.BaseController):
         context = self._get_context()
         c.user_dict = tk.get_action('user_show')(context, {'id': id, 'include_num_followers': True})
         url_func = functools.partial(user_datarequest_url, id=id)
-        return self._show_index(id, None, True, url_func, 'user/datarequests.html')
+        return self._show_index(id, request.GET.get('organization', ''), True, url_func, 'user/datarequests.html')
 
     def close(self, id):
         data_dict = {'id': id}

--- a/ckanext/datarequests/plugin.py
+++ b/ckanext/datarequests/plugin.py
@@ -145,6 +145,12 @@ class DataRequestsPlugin(p.SingletonPlugin):
                   action='organization_datarequests', conditions=dict(method=['GET']),
                   ckan_icon='question-sign')
 
+        # Data Request that belongs to an user
+        m.connect('user_datarequests', '/user/%s/{id}' % constants.DATAREQUESTS_MAIN_PATH,
+                  controller='ckanext.datarequests.controllers.ui_controller:DataRequestsUI',
+                  action='user_datarequests', conditions=dict(method=['GET']),
+                  ckan_icon='question-sign')
+
         if self.comments_enabled:
             # Comment, update and view comments (of) a Data Request
             m.connect('datarequest_comment', '/%s/comment/{id}' % constants.DATAREQUESTS_MAIN_PATH,

--- a/ckanext/datarequests/templates/datarequests/snippets/datarequest_form.html
+++ b/ckanext/datarequests/templates/datarequests/snippets/datarequest_form.html
@@ -2,7 +2,7 @@
 
 {% set title = data.get('title', '') %}
 {% set description = data.get('description', '') %}
-{% set organization_id = data.get('organization_id', '') %}
+{% set organization_id = data.get('organization_id', h.get_request_param('organization')) %}
 {% set organizations_available = h.organizations_available('read') %}
 
 {# This provides a full page that renders a form for publishing a dataset. It can

--- a/ckanext/datarequests/templates/organization/datarequests.html
+++ b/ckanext/datarequests/templates/organization/datarequests.html
@@ -7,7 +7,7 @@
 {% block page_primary_action %}
   {% if h.check_access('datarequest_create') %}
     <div class="page_primary_action">
-      {% link_for _('Add Data Request'), controller='ckanext.datarequests.controllers.ui_controller:DataRequestsUI', action='new', class_='btn btn-primary', icon='plus-sign-alt' %}
+      {% link_for _('Add Data Request'), controller='ckanext.datarequests.controllers.ui_controller:DataRequestsUI', action='new', organization=c.group_dict.id, class_='btn btn-primary', icon='plus-sign-alt' %}
     </div>
   {% endif %}
   {{ h.snippet('datarequests/snippets/datarequest_list.html', datarequest_count=c.datarequest_count, datarequests=c.datarequests, page=c.page)}}

--- a/ckanext/datarequests/templates/user/datarequests.html
+++ b/ckanext/datarequests/templates/user/datarequests.html
@@ -12,6 +12,6 @@
 {% block secondary_content %}
   {{ super() }}
   {% for facet in c.facet_titles %}
-    {{ h.snippet('snippets/facet_list.html', title=c.facet_titles[facet], name=facet, extras={'id': c.group_dict.name}) }}
+    {{ h.snippet('snippets/facet_list.html', title=c.facet_titles[facet], name=facet, extras={'id': c.user_dict.name}) }}
   {% endfor %}
 {% endblock %}

--- a/ckanext/datarequests/templates/user/datarequests.html
+++ b/ckanext/datarequests/templates/user/datarequests.html
@@ -1,15 +1,11 @@
-{% extends "organization/read_base.html" %}
+{% extends "user/read_base.html" %}
+
 {% block styles %}
   {{ super() }}
   <link rel="stylesheet" href="/datarequests.css" />
 {% endblock %}
 
 {% block page_primary_action %}
-  {% if h.check_access('datarequest_create') %}
-    <div class="page_primary_action">
-      {% link_for _('Add Data Request'), controller='ckanext.datarequests.controllers.ui_controller:DataRequestsUI', action='new', class_='btn btn-primary', icon='plus-sign-alt' %}
-    </div>
-  {% endif %}
   {{ h.snippet('datarequests/snippets/datarequest_list.html', datarequest_count=c.datarequest_count, datarequests=c.datarequests, page=c.page)}}
 {% endblock %}
 

--- a/ckanext/datarequests/templates/user/read_base.html
+++ b/ckanext/datarequests/templates/user/read_base.html
@@ -1,0 +1,7 @@
+{% ckan_extends %}
+
+{% block content_primary_nav %}
+  {{ h.build_nav_icon('user_datasets', _('Datasets'), id=user.name) }}
+  {{ h.build_nav_icon('user_activity_stream', _('Activity Stream'), id=user.name) }}
+  {{ h.build_nav_icon('user_datarequests', _('Data Requests'), id=user.name) }}
+{% endblock %}

--- a/ckanext/datarequests/tests/test_actions.py
+++ b/ckanext/datarequests/tests/test_actions.py
@@ -384,12 +384,13 @@ class ActionsTest(unittest.TestCase):
         ddbb_response = test_case['ddbb_response']
         expected_response = test_case['expected_response']
         _organization_show = test_case['organization_show_func']
+        _user_show = test_case.get('user_show_func', None)
 
         # Set the mocks
         actions.db.DataRequest.get_ordered_by_date.return_value = ddbb_response
         default_pkg = {'pkg': 1}
         default_org = {'org': 2}
-        default_user = {'user': 3}
+        default_user = {'user': 3, 'id': test_data.user_default_id}
         test_data._initialize_basic_actions(actions, default_user, default_org, default_pkg)
 
         # Modify the default behaviour of 'organization_show'

--- a/ckanext/datarequests/tests/test_actions_data.py
+++ b/ckanext/datarequests/tests/test_actions_data.py
@@ -194,6 +194,7 @@ org1 = 'org1'
 org2 = 'org2'
 org3 = 'org3'
 organization_default_id = 'organziation_id'
+user_default_id = 'user_id'
 default_offset = 2
 default_limit = 3
 
@@ -378,8 +379,8 @@ datarequest_index_test_case_11 = {
 
 datarequest_index_test_case_12 = {
     'organization_show_func': _organization_show,
-    'content': {'organization_id': 'fiware', 'closed': True, 'offset': default_offset, 'limit': default_limit},
-    'expected_ddbb_params': {'organization_id': organization_default_id, 'closed': True},
+    'content': {'organization_id': 'fiware', 'user_id': 'ckan', 'closed': True, 'offset': default_offset, 'limit': default_limit},
+    'expected_ddbb_params': {'organization_id': organization_default_id, 'closed': True, 'user_id': user_default_id},
     'ddbb_response': ddbb_response_2,
     'expected_response': expected_result_3
 }

--- a/ckanext/datarequests/tests/test_plugin.py
+++ b/ckanext/datarequests/tests/test_plugin.py
@@ -134,7 +134,8 @@ class DataRequestPlutinTest(unittest.TestCase):
     ])
     def test_before_map(self, comments_enabled):
 
-        mapa_calls = 9 if comments_enabled == 'True' else 9 - 2
+        urls_set = 10
+        mapa_calls = urls_set if comments_enabled == 'True' else urls_set - 2
 
         # Configure config and get instance
         plugin.config.get.return_value = comments_enabled
@@ -176,6 +177,12 @@ class DataRequestPlutinTest(unittest.TestCase):
             action='organization_datarequests', conditions=dict(method=['GET']), 
             ckan_icon='question-sign')
 
+        mapa.connect.assert_any_call('user_datarequests',
+            '/user/%s/{id}' % dr_basic_path,
+            controller='ckanext.datarequests.controllers.ui_controller:DataRequestsUI',
+            action='user_datarequests', conditions=dict(method=['GET']), 
+            ckan_icon='question-sign')
+
         if comments_enabled == 'True':
             mapa.connect.assert_any_call('datarequest_comment', '/%s/comment/{id}' % dr_basic_path,
                 controller='ckanext.datarequests.controllers.ui_controller:DataRequestsUI',
@@ -184,3 +191,17 @@ class DataRequestPlutinTest(unittest.TestCase):
             mapa.connect.assert_any_call('/%s/comment/{datarequest_id}/delete/{comment_id}' % dr_basic_path,
                 controller='ckanext.datarequests.controllers.ui_controller:DataRequestsUI',
                 action='delete_comment', conditions=dict(method=['GET', 'POST']))
+
+    @parameterized.expand([
+        ('True',),
+        ('False')
+    ])
+    def test_helpers(self, comments_enabled):
+
+        # Configure config and get instance
+        plugin.config.get.return_value = comments_enabled
+        self.plg_instance = plugin.DataRequestsPlugin()
+
+        # Check result
+        expected_result = True if comments_enabled == 'True' else False
+        self.assertEquals(self.plg_instance.get_helpers()['show_comments_tab'](), expected_result)

--- a/ckanext/datarequests/tests/test_ui_controller.py
+++ b/ckanext/datarequests/tests/test_ui_controller.py
@@ -519,7 +519,7 @@ class UIControllerTest(unittest.TestCase):
         result = function(**params)
 
         # Assertions
-        controller.tk.check_access.assert_called_once_with(constants.DATAREQUEST_INDEX, self.expected_context, expected_data_dict)        
+        controller.tk.check_access.assert_called_once_with(constants.DATAREQUEST_INDEX, self.expected_context, expected_data_dict)
 
         # Specific assertions depending on the function called
         if func == 'index':
@@ -858,7 +858,7 @@ class UIControllerTest(unittest.TestCase):
 
 
     ######################################################################
-    ############################### COMMENT ##############################
+    ########################### DELETE COMMENT ###########################
     ######################################################################
 
     def test_delete_comment_not_authorized(self):


### PR DESCRIPTION
Fix #4: In the user profile page there is a new tab to visualize all the data requests created by this user.