### PR TITLE
fix: added missing template context variable `group_type`

### DIFF
--- a/ckanext/datarequests/controllers/ui_controller.py
+++ b/ckanext/datarequests/controllers/ui_controller.py
@@ -149,7 +149,11 @@ class DataRequestsUI(base.BaseController):
             if include_organization_facet is True:
                 c.facet_titles['organization'] = tk._('Organizations')
 
-            return tk.render(file_to_render)
+            extra_vars = {}
+            if hasattr(c, 'group_dict'):
+                extra_vars.update({'group_type': c.group_dict.get('type')})
+
+            return tk.render(file_to_render, extra_vars=extra_vars)
         except ValueError as e:
             # This exception should only occur if the page value is not valid
             log.warn(e)

--- a/ckanext/datarequests/controllers/ui_controller.py
+++ b/ckanext/datarequests/controllers/ui_controller.py
@@ -149,9 +149,9 @@ class DataRequestsUI(base.BaseController):
             if include_organization_facet is True:
                 c.facet_titles['organization'] = tk._('Organizations')
 
-            extra_vars = {}
-            if hasattr(c, 'group_dict'):
-                extra_vars.update({'group_type': c.group_dict.get('type')})
+            extra_vars = {'group_type': ''}
+            if hasattr(c, 'group_dict') and isinstance(c.group_dict, dict):
+                extra_vars.update({'group_type': c.group_dict.get('type', '')})
 
             return tk.render(file_to_render, extra_vars=extra_vars)
         except ValueError as e:


### PR DESCRIPTION
This PR fixes issue #36 and makes the extension compatible with the newly released `ckan-2.8.0`