### PR TITLE
Correct display of time during data-request creation , closing of data-request and while commenting

### DIFF
--- a/ckanext/datarequests/actions.py
+++ b/ckanext/datarequests/actions.py
@@ -211,7 +211,7 @@ def create_datarequest(context, data_dict):
     data_req = db.DataRequest()
     _undictize_datarequest_basic(data_req, data_dict)
     data_req.user_id = context['auth_user_obj'].id
-    data_req.open_time = datetime.datetime.now()
+    data_req.open_time = datetime.datetime.utcnow()
 
     session.add(data_req)
     session.commit()    
@@ -563,7 +563,7 @@ def close_datarequest(context, data_dict):
 
     data_req.closed = True
     data_req.accepted_dataset_id = data_dict.get('accepted_dataset_id', None)
-    data_req.close_time = datetime.datetime.now()
+    data_req.close_time = datetime.datetime.utcnow()
 
     session.add(data_req)
     session.commit()
@@ -616,7 +616,7 @@ def comment_datarequest(context, data_dict):
     comment = db.Comment()
     _undictize_comment_basic(comment, data_dict)
     comment.user_id = context['auth_user_obj'].id
-    comment.time = datetime.datetime.now()
+    comment.time = datetime.datetime.utcnow()
 
     session.add(comment)
     session.commit()


### PR DESCRIPTION
Fixes #38 

 The fix includes below scenarios:

1. The correct time when a data request is created.
-> it will now show "Just now " instead of "-1 days ago " earlier.

2. The correct time when a data request is closed

3. The correct time while commenting on the respective data-request as shown below

![image](https://user-images.githubusercontent.com/36654563/57528147-26148380-734f-11e9-9f9f-c7c498b8a148.png)

Thus, this fix has also been resolved in this PR.