### PR TITLE
Correct display of time during data-request creation, closing of data-request and while commenting

### DIFF
--- a/ckanext/datarequests/actions.py
+++ b/ckanext/datarequests/actions.py
@@ -211,7 +211,7 @@ def create_datarequest(context, data_dict):
     data_req = db.DataRequest()
     _undictize_datarequest_basic(data_req, data_dict)
     data_req.user_id = context['auth_user_obj'].id
-    data_req.open_time = datetime.datetime.now()
+    data_req.open_time = datetime.datetime.utcnow()
 
     session.add(data_req)
     session.commit()    
@@ -563,7 +563,7 @@ def close_datarequest(context, data_dict):
 
     data_req.closed = True
     data_req.accepted_dataset_id = data_dict.get('accepted_dataset_id', None)
-    data_req.close_time = datetime.datetime.now()
+    data_req.close_time = datetime.datetime.utcnow()
 
     session.add(data_req)
     session.commit()
@@ -616,7 +616,7 @@ def comment_datarequest(context, data_dict):
     comment = db.Comment()
     _undictize_comment_basic(comment, data_dict)
     comment.user_id = context['auth_user_obj'].id
-    comment.time = datetime.datetime.now()
+    comment.time = datetime.datetime.utcnow()
 
     session.add(comment)
     session.commit()

--- a/ckanext/datarequests/tests/test_actions.py
+++ b/ckanext/datarequests/tests/test_actions.py
@@ -341,8 +341,8 @@ class ActionsTest(unittest.TestCase):
     @patch('ckanext.datarequests.actions._send_mail')
     def test_create_datarequest_valid(self, send_mail_mock):
         # Configure the mocks
-        current_time = self._datetime.datetime.now()
-        actions.datetime.datetime.now = MagicMock(return_value=current_time)
+        current_time = self._datetime.datetime.utcnow()
+        actions.datetime.datetime.utcnow = MagicMock(return_value=current_time)
 
         # Mock actions
         default_user = {'user': 1}
@@ -430,7 +430,7 @@ class ActionsTest(unittest.TestCase):
         datarequest = test_data._generate_basic_datarequest()
         datarequest.organization_id = organization_id
         datarequest.accepted_dataset_id = 'example_uuidv4_package'
-        datarequest.close_time = datetime.datetime.now()
+        datarequest.close_time = datetime.datetime.utcnow()
         datarequest.closed = True
 
         org_checked = True if organization_id else False
@@ -693,8 +693,8 @@ class ActionsTest(unittest.TestCase):
     ])
     def test_close_datarequest(self, data, expected_accepted_ds, organization_id):
         # Configure the mock
-        current_time = self._datetime.datetime.now()
-        actions.datetime.datetime.now = MagicMock(return_value=current_time)
+        current_time = self._datetime.datetime.utcnow()
+        actions.datetime.datetime.utcnow = MagicMock(return_value=current_time)
         datarequest = test_data._generate_basic_datarequest()
         datarequest.organization_id = organization_id
         datarequest.accepted_dataset_id = None
@@ -774,9 +774,9 @@ class ActionsTest(unittest.TestCase):
     @patch('ckanext.datarequests.actions._get_datarequest_involved_users')
     def test_comment(self, get_datarequest_involved_users_mock, send_mail_mock):
         # Configure the mocks
-        current_time = self._datetime.datetime.now()
+        current_time = self._datetime.datetime.utcnow()
         datarequest_dict = MagicMock()
-        actions.datetime.datetime.now = MagicMock(return_value=current_time)
+        actions.datetime.datetime.utcnow = MagicMock(return_value=current_time)
         actions.validator.validate_comment.return_value = datarequest_dict
 
         # User

--- a/ckanext/datarequests/tests/test_actions_data.py
+++ b/ckanext/datarequests/tests/test_actions_data.py
@@ -92,7 +92,7 @@ def _generate_basic_datarequest(id=DATAREQUEST_ID, user_id='example_uuidv4_user'
     datarequest.title = title
     datarequest.description = description
     datarequest.organization_id = organization_id
-    datarequest.open_time = datetime.datetime.now()
+    datarequest.open_time = datetime.datetime.utcnow()
     datarequest.closed = closed
     datarequest.close_time = None
     datarequest.accepted_dataset_id = None
@@ -108,7 +108,7 @@ def _generate_basic_comment(id=COMMENT_ID, user_id='example_uuidv4_user',
     comment.user_id = user_id
     comment.comment = comment
     comment.datarequest_id = datarequest_id
-    comment.time = datetime.datetime.now()
+    comment.time = datetime.datetime.utcnow()
 
     return comment
 


### PR DESCRIPTION
Fixes #38 

The fix includes below scenarios:

1. The correct time when a data request is created.
-> it will now show "Just now " instead of "-1 days ago " earlier.

2. The correct time when a data request is closed

3. The correct time while commenting on the respective data-request. Thus, this fix has also been resolved in this PR.