### PR TITLE
Feature/data requests description mandatory

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,10 @@ ckan.datarequests.comments = [true|false]
 ```
 ckan.datarequests.show_datarequests_badge = [true|false]
 ```
+* Enable or disable description as a required field on data request forms
+```
+ckan.datarequests.description_required = [true|false]
+```
 * Restart your apache2 reserver
 ```
 sudo service apache2 restart

--- a/README.md
+++ b/README.md
@@ -207,9 +207,9 @@ ckan.datarequests.comments = [true|false]
 ```
 ckan.datarequests.show_datarequests_badge = [true|false]
 ```
-* Enable or disable description as a required field on data request forms
+* Enable or disable description as a required field on data request forms. False by default
 ```
-ckan.datarequests.description_required = [true|false]
+ckan.datarequests.description_required = [True|False]
 ```
 * Restart your apache2 reserver
 ```

--- a/ckanext/datarequests/plugin.py
+++ b/ckanext/datarequests/plugin.py
@@ -68,6 +68,7 @@ class DataRequestsPlugin(p.SingletonPlugin):
         self.comments_enabled = get_config_bool_value('ckan.datarequests.comments', True)
         self._show_datarequests_badge = get_config_bool_value('ckan.datarequests.show_datarequests_badge')
         self.name = 'datarequests'
+        self.is_description_required = get_config_bool_value('ckan.datarequests.description_required', False)
 
     ######################################################################
     ############################## IACTIONS ##############################
@@ -215,7 +216,8 @@ class DataRequestsPlugin(p.SingletonPlugin):
             'get_open_datarequests_number': helpers.get_open_datarequests_number,
             'get_open_datarequests_badge': partial(helpers.get_open_datarequests_badge, self._show_datarequests_badge),
             'get_plus_icon': get_plus_icon,
-            'is_following_datarequest': helpers.is_following_datarequest
+            'is_following_datarequest': helpers.is_following_datarequest,
+            'is_description_required': self.is_description_required
         }
 
     ######################################################################

--- a/ckanext/datarequests/templates/datarequests/snippets/datarequest_form.html
+++ b/ckanext/datarequests/templates/datarequests/snippets/datarequest_form.html
@@ -5,6 +5,7 @@
 {% set organization_id = data.get('organization_id', h.get_request_param('organization')) %}
 {% set organizations_available = h.organizations_available('read') %}
 {% set form_horizontal = 'form-horizontal' if h.ckan_version()[:3] <= '2.7' else '' %}
+{% set description_required = h.is_description_required %}
 
 {# This provides a full page that renders a form for publishing a dataset. It can
 then itself be extended to add/remove blocks of functionality. #}
@@ -19,7 +20,7 @@ then itself be extended to add/remove blocks of functionality. #}
   {% endblock %}
 
   {% block offering_description %}
-    {{ form.markdown('description', id='field-description', label=_('Description'), placeholder=_('eg. Data Request description'), value=description, error=errors['Description']) }}
+  {{ form.markdown('description', id='field-description', label=_('Description'), placeholder=_('eg. Data Request description'), value=description, error=errors['Description'], is_required=description_required) }}
   {% endblock %}
 
   <div class="control-group form-group">

--- a/ckanext/datarequests/validator.py
+++ b/ckanext/datarequests/validator.py
@@ -20,6 +20,7 @@
 import constants
 import ckan.plugins.toolkit as tk
 import ckanext.datarequests.db as db
+import plugin as datarequests
 
 
 def validate_datarequest(context, request_data):
@@ -41,6 +42,9 @@ def validate_datarequest(context, request_data):
             errors[tk._('Title')] = [tk._('That title is already in use')]
 
     # Check description
+    if datarequests.get_config_bool_value('ckan.datarequests.description_required', False) and not request_data['description']:
+        errors[tk._('Description')] = [tk._('Description cannot be empty')]
+
     if len(request_data['description']) > constants.DESCRIPTION_MAX_LENGTH:
         errors[tk._('Description')] = [tk._('Description must be a maximum of %d characters long') % constants.DESCRIPTION_MAX_LENGTH]
 


### PR DESCRIPTION
**Purpose**
This pull request adds functionality to set description field as mandatory.

**Approach**
Configurable 'description_required' option in CKAN config file (default is False)
If 'description_required' is set to True, when a user is creating or updating a data request, the description field is mandatory. 
An error message is displayed on front end for invalid entries.

<img width="878" alt="Screen Shot 2020-02-21 at 11 55 33 AM" src="https://user-images.githubusercontent.com/37602611/75063087-6178dc80-54a1-11ea-9c5f-55043a397b3d.png">
